### PR TITLE
Support lower case header field `Location`

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -155,7 +155,7 @@ install() {
       echo_with_date "未安装微信小助手，也没有下载过安装包，所以即使使用了 -n 参数，仍需要检查并下载新版本"
     fi
     echo_with_date "正在查询新版本……"
-    latest_version=$(curl --retry 2 -I -s https://github.com/MustangYM/WeChatExtension-ForMac/releases/latest | grep Location | sed -n 's/.*\/v\(.*\)/\1/p')
+    latest_version=$(curl --retry 2 -I -s https://github.com/MustangYM/WeChatExtension-ForMac/releases/latest | grep -i Location | sed -n 's/.*\/v\(.*\)/\1/p')
     if [[ -z "$latest_version" ]]; then
       echo_with_date "查询新版本时失败，请稍后重试"
       exit 1


### PR DESCRIPTION
In some version of curl, like `v7.64.1`, the response header field is showing by lower casing. And `grep` command cannot find `Location` when there is `location` actually.

![image](https://user-images.githubusercontent.com/3380894/75572759-5ff97680-5a96-11ea-8e6e-1c357a43160a.png)
