### PR TITLE
fix: 修改对于 version 的获取

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -9,7 +9,7 @@ echo_with_date "当前 Oh My WeChat 版本为 v${omw_version}"
 
 # 从 GitHub 获取 owm 版本号
 get_omw_latest_version_from_github() {
-  curl --retry 2 -I -s https://github.com/lmk123/oh-my-wechat/releases/latest | grep Location | sed -n 's/.*\/v\(.*\)/\1/p'
+  curl --retry 2 -I -s https://github.com/lmk123/oh-my-wechat/releases/latest | grep -i Location | sed -n 's/.*\/tag\/v\(.*\)/\1/p'
 }
 
 get_download_url() {
@@ -17,7 +17,7 @@ get_download_url() {
 }
 
 get_latest_version() {
-  curl --retry 2 -I -s https://github.com/MustangYM/WeChatExtension-ForMac/releases/latest | grep Location | sed -n 's/.*\/v\(.*\)/\1/p'
+  curl --retry 2 -I -s https://github.com/MustangYM/WeChatExtension-ForMac/releases/latest | grep -i Location | sed -n 's/.*\/tag\/v\(.*\)/\1/p'
 }
 
 # 保存一下 -n 参数，给 install 方法作为参数用


### PR DESCRIPTION
1月21日，我在使用`omw`的时候老是发生错误，在 debug 过程中发现`omw`无法正确获取版本号，后发现在获取版本的请求中，`location`请求头已经变成了小写，原脚本只匹配了大写，导致无法正常获取版本号
```http
location: https://github.com/MustangYM/WeChatExtension-ForMac/releases/tag/v2.8.2
```
此次修正了版本号的获取，并增强了正则匹配规则