### PR TITLE
修复mac下 "/i" 引起的sed command报错问题

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -9,7 +9,7 @@ echo_with_date "当前 Oh My WeChat 版本为 v${omw_version}"
 
 # 从 GitHub 获取 owm 版本号
 get_omw_latest_version_from_github() {
-  curl --retry 2 -I -s https://github.com/lmk123/oh-my-wechat/releases/latest | grep -i Location: | sed -n 's/.*\/v\(.*\)/\1/ip'
+  curl --retry 2 -I -s https://github.com/lmk123/oh-my-wechat/releases/latest | grep -i Location: | sed -n 's/.*\/v\(.*\)/\1/p'
 }
 
 get_download_url() {
@@ -17,7 +17,7 @@ get_download_url() {
 }
 
 get_latest_version() {
-  curl --retry 2 -I -s https://github.com/MustangYM/WeChatExtension-ForMac/releases/latest | grep -i Location: | sed -n 's/.*\/v\(.*\)/\1/ip'
+  curl --retry 2 -I -s https://github.com/MustangYM/WeChatExtension-ForMac/releases/latest | grep -i Location: | sed -n 's/.*\/v\(.*\)/\1/p'
 }
 
 # 保存一下 -n 参数，给 install 方法作为参数用


### PR DESCRIPTION
MacOS 10.15.7之后运行update等命令后会出现sed命令错误如下：
```sed: 1: "s/.*\/v\(.*\)/\1/ip": bad flag in substitute command: 'i'```

修复后可以成功安装
MacOS 10.15.7下测试通过
<img width="551" alt="image" src="https://user-images.githubusercontent.com/23567445/109740338-14782c00-7c06-11eb-967e-efb22e4a0699.png">
其他低版本等待测试反馈


