### PR TITLE
Revert "修复版本号大小写匹配问题"

### DIFF
--- a/main.sh
+++ b/main.sh
@@ -9,7 +9,7 @@ echo_with_date "当前 Oh My WeChat 版本为 v${omw_version}"
 
 # 从 GitHub 获取 owm 版本号
 get_omw_latest_version_from_github() {
-  curl --retry 2 -I -s https://github.com/lmk123/oh-my-wechat/releases/latest | grep -i Location: | sed -n 's/.*\/v\(.*\)/\1/ip'
+  curl --retry 2 -I -s https://github.com/lmk123/oh-my-wechat/releases/latest | grep -i Location: | sed -n 's/.*\/v\(.*\)/\1/p'
 }
 
 get_download_url() {
@@ -17,7 +17,7 @@ get_download_url() {
 }
 
 get_latest_version() {
-  curl --retry 2 -I -s https://github.com/MustangYM/WeChatExtension-ForMac/releases/latest | grep -i Location: | sed -n 's/.*\/v\(.*\)/\1/ip'
+  curl --retry 2 -I -s https://github.com/MustangYM/WeChatExtension-ForMac/releases/latest | grep -i Location: | sed -n 's/.*\/v\(.*\)/\1/p'
 }
 
 # 保存一下 -n 参数，给 install 方法作为参数用


### PR DESCRIPTION
Reverts lmk123/oh-my-wechat#91

微信小助手已经将 2.3.8 的版本发布名称改为了以小写 v 开头的 `v2.8.3`，为了最快速解决 `i` 标识在 macOS 10.15 及以下版本中不可用的问题，我准备回退这个 PR 并给 omw 发布一个新版本。

最好的解决办法见 #101